### PR TITLE
fix(web): fix BSB links

### DIFF
--- a/packages/web/src/components/open-external-button.tsx
+++ b/packages/web/src/components/open-external-button.tsx
@@ -21,7 +21,7 @@ const makeUrl = (
   const chapter = verseKey.chapter;
 
   if (translation === Translation.BSB) {
-    return `https://biblehub.com/bsb/${book}/${chapter}.htm`;
+    return `https://biblemenus.com/search.php?q=${book}+${chapter}`;
   }
 
   if (translation === Translation.NET) {


### PR DESCRIPTION
Hi, thanks for making this Bible search app, it's quite helpful. 

I noticed the BSB links weren't working (biblehub must've changed their search format), so I started going down the path of making the book name lowercase, and converting spaces to underscores (turning `1 Corinthians 8` into `https://biblehub.com/bsb/1_corinthians/8.htm`), but then I noticed that the search bar on biblehub was sending queries to `https://biblemenus.com/search.php`, and you can throw pretty much any format at it, and it redirects nicely back to the appropriate biblehub link.

I tried this locally, and it seems to work nicely. Notice anything I should change? Thanks!